### PR TITLE
[Feat] 이야기 페이지 최근 올라온 스토리 섹션 구현

### DIFF
--- a/src/apis/story/getRecentStories.js
+++ b/src/apis/story/getRecentStories.js
@@ -1,0 +1,8 @@
+import api from "@apis/instance/api";
+
+export const getRecentStories = async (size) => {
+  const res = await api.get("/story/public/all", {
+    params: size ? { size } : {},
+  });
+  return res.data;
+};

--- a/src/apis/story/queries.js
+++ b/src/apis/story/queries.js
@@ -30,14 +30,5 @@ export const usePatchStoryLike = (storyId) => {
         };
       });
     },
-    onError: (error) => {
-      if (error?.response?.status === 401) {
-        alert("로그인이 필요합니다.");
-      } else if (error?.response?.status === 400) {
-        alert("이미 응원하신 스토리입니다.");
-      } else {
-        alert("응원 요청이 실패했습니다. 다시 시도해주세요.");
-      }
-    },
   });
 };

--- a/src/apis/story/queries.js
+++ b/src/apis/story/queries.js
@@ -22,6 +22,7 @@ export const usePatchStoryLike = (storyId) => {
   return useMutation({
     mutationFn: () => patchStoryLike(storyId),
     onSuccess: () => {
+      // 상세 페이지 캐시 업데이트
       queryClient.setQueryData(["bestStoryDetail", storyId], (old) => {
         if (!old) return old;
         return {
@@ -29,6 +30,25 @@ export const usePatchStoryLike = (storyId) => {
           storyLikes: old.storyLikes + 1,
         };
       });
+
+      // 최근 스토리 목록 캐시 업데이트
+      queryClient.setQueryData(["recentStory"], (old) => {
+        if (!Array.isArray(old)) return old;
+        return old.map((story) =>
+          story.storyId === Number(storyId)
+            ? { ...story, likes: (story.likes || 0) + 1 }
+            : story,
+        );
+      });
     },
+  });
+};
+
+import { getRecentStories } from "@/apis/story/getRecentStories";
+
+export const useGetRecentStory = (size = 10) => {
+  return useQuery({
+    queryKey: ["recentStory"],
+    queryFn: () => getRecentStories(size),
   });
 };

--- a/src/pages/story/StoryPage.jsx
+++ b/src/pages/story/StoryPage.jsx
@@ -8,7 +8,7 @@ const StoryPage = () => {
 
   return (
     <div className="h-[calc(100vh-5.25rem)] overflow-y-auto scrollbar-hide p-5">
-      <h1 className="h3 mt-10">많은 응원을 받은 이야기</h1>
+      <h1 className="h3 mt-20">많은 응원을 받은 이야기</h1>
       {isLoading && (
         <div className="absolute inset-0 z-50 bg-white bg-opacity-80 flex flex-col justify-center items-center">
           <div className="loader"></div>
@@ -17,7 +17,6 @@ const StoryPage = () => {
       )}
       <BestStoryCarousel data={bestData} isLoading={isLoading} />
       <h1 className="h3 mt-10">최근 올라온 스토리</h1>
-      <CategoryCarousel />
       <StoryCarousel />
     </div>
   );

--- a/src/pages/story/components/StoryDetail.jsx
+++ b/src/pages/story/components/StoryDetail.jsx
@@ -1,9 +1,10 @@
 import { useParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import useUIStore from "@/store/uiStore";
 import { useGetBestStoryDetail } from "@/apis/story/queries";
 import { usePatchStoryLike } from "@/apis/story/queries";
+import HaveToLoginModal from "@/pages/map/components/HaveToLoginModal";
 
 const StoryDetail = () => {
   const navigate = useNavigate();
@@ -20,8 +21,39 @@ const StoryDetail = () => {
   const { mutate: likeStory } = usePatchStoryLike(storyId);
 
   const handleLike = () => {
-    likeStory(); // 좋아요 요청 및 낙관적 업데이트 실행
+    likeStory(undefined, {
+      onError: (error) => {
+        const status = error?.response?.status;
+
+        if (status === 401) {
+          setErrorModal({
+            open: true,
+            message: "로그인이 필요합니다.",
+            subMessage: "응원 기능은 로그인 후 이용할 수 있어요!",
+          });
+        } else if (status === 400) {
+          setErrorModal({
+            open: true,
+            message: "이미 응원하신 스토리입니다.",
+            subMessage: "아쉽지만 한 번만 응원할 수 있어요",
+          });
+        } else {
+          setErrorModal({
+            open: true,
+            message: "응원 요청 실패",
+            subMessage: "잠시 후 다시 시도해주세요.",
+          });
+        }
+      },
+    });
   };
+
+  // 모달 상태 구조
+  const [errorModal, setErrorModal] = useState({
+    open: false,
+    message: "",
+    subMessage: "",
+  });
 
   return (
     <div className="flex flex-col p-5 overflow-y-auto scrollbar-hide">
@@ -86,6 +118,15 @@ const StoryDetail = () => {
           <p className="b1">응원하기</p>
         </button>
       </div>
+
+      {errorModal.open && (
+        <HaveToLoginModal
+          message={errorModal.message}
+          subMessage={errorModal.subMessage}
+          onClose={() => setErrorModal({ ...errorModal, open: false })}
+          showButton={errorModal.message === "로그인이 필요합니다."}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/story/components/carousel/StoryCarousel.jsx
+++ b/src/pages/story/components/carousel/StoryCarousel.jsx
@@ -1,97 +1,69 @@
-import { useRef } from "react";
-import StoryContent from "@/pages/story/components/content/StoryContent";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getRecentStories } from "@apis/story/getRecentStories";
 
 const StoryCarousel = () => {
-  const contentSample = [
-    {
-      num: 5,
-      title: "A 업체",
-      img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqKuLDrxGqOTapgqfxl13u_xeeiDpbr7LSgA&s",
-    },
-    {
-      num: 6,
-      title: "A 업체",
-      img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqKuLDrxGqOTapgqfxl13u_xeeiDpbr7LSgA&s",
-    },
-    {
-      num: 7,
-      title: "A 업체",
-      img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqKuLDrxGqOTapgqfxl13u_xeeiDpbr7LSgA&s",
-    },
-    {
-      num: 8,
-      title: "A 업체",
-      img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqKuLDrxGqOTapgqfxl13u_xeeiDpbr7LSgA&s",
-    },
-    {
-      num: 9,
-      title: "A 업체",
-      img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqKuLDrxGqOTapgqfxl13u_xeeiDpbr7LSgA&s",
-    },
-    {
-      num: 10,
-      title: "A 업체",
-      img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqKuLDrxGqOTapgqfxl13u_xeeiDpbr7LSgA&s",
-    },
-    {
-      num: 11,
-      title: "A 업체",
-      img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTqKuLDrxGqOTapgqfxl13u_xeeiDpbr7LSgA&s",
-    },
-  ];
+  const [stories, setStories] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
 
-  const scrollRef = useRef(null);
-  let isDown = false;
-  let startX = 0;
-  let scrollLeft = 0;
+  useEffect(() => {
+    const fetchStories = async () => {
+      try {
+        const data = await getRecentStories(10);
+        setStories(data);
+      } catch (err) {
+        console.error("최근 스토리 조회 실패:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
 
-  const handleMouseDown = (e) => {
-    isDown = true;
-    const slider = scrollRef.current;
-    slider.classList.add("grabbing");
-    startX = e.pageX - slider.offsetLeft;
-    scrollLeft = slider.scrollLeft;
-  };
+    fetchStories();
+  }, []);
 
-  const handleMouseLeave = () => {
-    isDown = false;
-    scrollRef.current.classList.remove("grabbing");
-  };
-
-  const handleMouseUp = () => {
-    isDown = false;
-    scrollRef.current.classList.remove("grabbing");
-  };
-
-  const handleMouseMove = (e) => {
-    if (!isDown) return;
-    e.preventDefault();
-    const slider = scrollRef.current;
-    const x = e.pageX - slider.offsetLeft;
-    const walk = (x - startX) * 1.6; // sensitivity 조정 가능
-    slider.scrollLeft = scrollLeft - walk;
-  };
+  if (loading) {
+    return <p className="text-gray-500 mt-4">스토리를 불러오는 중입니다…</p>;
+  }
 
   return (
-    <div
-      ref={scrollRef}
-      className="w-full m-5 overflow-x-auto whitespace-nowrap scrollbar-hide cursor-grab"
-      onMouseDown={handleMouseDown}
-      onMouseLeave={handleMouseLeave}
-      onMouseUp={handleMouseUp}
-      onMouseMove={handleMouseMove}
-    >
-      <div className="inline-flex gap-2">
-        {contentSample.map((item, idx) => (
-          <StoryContent
-            key={idx}
-            title={item.title}
-            img={item.img}
-            idx={idx}
-            num={item.num}
+    <div className="flex gap-4 overflow-x-auto scrollbar-hide mt-4 px-1">
+      {stories.map((story) => (
+        <div
+          key={story.storyId}
+          onClick={() => navigate(`/story/${story.storyId}`)}
+          className="relative w-[15.9375rem] sm:w-[17rem] md:w-[18rem] aspect-[255/182] flex-shrink-0 rounded-[0.5rem] overflow-hidden cursor-pointer"
+        >
+          <img
+            src={story.imageUrl}
+            alt={story.storyTitle}
+            className="absolute w-full h-full object-cover"
           />
-        ))}
-      </div>
+
+          <img
+            src="/svgs/story/moveIcon.svg"
+            alt="이동 아이콘"
+            className="absolute top-5 right-5 w-5 h-5"
+          />
+
+          <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-4 flex flex-col gap-2">
+            <div className="flex items-center gap-1 bg-primary-3 rounded-lg w-fit px-1.5 py-0.5">
+              <img
+                src="/svgs/story/storyFireIcon.svg"
+                alt="fire"
+                className="w-4 h-4"
+              />
+              <span className="text-caption2 text-primary-8 font-semibold">
+                {story.likes || 0}
+              </span>
+            </div>
+
+            <h2 className="text-white font-semibold text-h4 break-keep">
+              {story.storyTitle}
+            </h2>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/pages/story/components/carousel/StoryCarousel.jsx
+++ b/src/pages/story/components/carousel/StoryCarousel.jsx
@@ -1,28 +1,11 @@
-import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { getRecentStories } from "@apis/story/getRecentStories";
+import { useGetRecentStory } from "@/apis/story/queries";
 
 const StoryCarousel = () => {
-  const [stories, setStories] = useState([]);
-  const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
+  const { data: stories = [], isLoading } = useGetRecentStory();
 
-  useEffect(() => {
-    const fetchStories = async () => {
-      try {
-        const data = await getRecentStories(10);
-        setStories(data);
-      } catch (err) {
-        console.error("최근 스토리 조회 실패:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchStories();
-  }, []);
-
-  if (loading) {
+  if (isLoading) {
     return <p className="text-gray-500 mt-4">스토리를 불러오는 중입니다…</p>;
   }
 
@@ -32,7 +15,7 @@ const StoryCarousel = () => {
         <div
           key={story.storyId}
           onClick={() => navigate(`/story/${story.storyId}`)}
-          className="relative w-[15.9375rem] sm:w-[17rem] md:w-[18rem] aspect-[255/182] flex-shrink-0 rounded-[0.5rem] overflow-hidden cursor-pointer"
+          className="relative w-64 sm:w-72 md:w-80 aspect-[255/182] flex-shrink-0 rounded-md overflow-hidden cursor-pointer"
         >
           <img
             src={story.imageUrl}

--- a/src/pages/story/components/content/SlideContent.jsx
+++ b/src/pages/story/components/content/SlideContent.jsx
@@ -31,7 +31,7 @@ const SlideContent = ({ data, title }) => {
       <div className="absolute bottom-5 left-0 w-full px-4 pt-6 pb-4 text-white">
         {/* 좋아요 아이콘 + 숫자 */}
         <div className="flex items-center mb-1">
-          <button className="flex gap-1 bg-primary-3 text-primary-8 b4 rounded-md pl-1 pr-1.5 py-0.5 justify-center items-center">
+          <button className="flex gap-1 bg-primary-3 text-primary-8 b4 rounded-lg  pl-1 pr-1.5 py-0.5 justify-center items-center">
             <img
               src="/svgs/story/storyFireIcon.svg"
               className="w-4 h-4"
@@ -41,7 +41,7 @@ const SlideContent = ({ data, title }) => {
           </button>
         </div>
         {/* 제목 */}
-        <div className="h3 text-white mt-4">{data.storyTitle}</div>
+        <div className="h3 font-semibold text-white mt-2 break-keep">{data.storyTitle}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 🌟 어떤 이유로 MR를 하셨나요?

- [x] feature 병합()
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 📝 세부 내용 - 왜 해당 MR이 필요한지 작업 내용을 자세하게 설명해주세요

- 이야기 페이지 하단에 최근 등록된 스토리 목록을 보여주는 `최근 올라온 스토리` 섹션을 구현했습니다. 

  - /story/public/all API 연동 (getRecentStories 작성)
  - 최근 스토리 데이터를 가져와 수평 스크롤 리스트 형태로 렌더링
  - 썸네일, 제목, 좋아요 수 표시 카드 UI 구성
  - StoryCarousel 컴포넌트 구현 및 반응형 대응 (rem, aspect-ratio 기반)
  - 특정 스토리 클릭 시 상세 페이지(/story/:storyId)로 라우팅

## 📸 작업 화면 스크린샷


https://github.com/user-attachments/assets/ab3c3a83-ceba-4156-ab37-06f1af0d2259



## ⚠️ MR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 📢 로컬 실행 시 유의사항

- /story/public/all 리스폰스에 좋아요 수 데이터가 없어서 백엔드 담당자 분께 요청한 상태입니다! 데이터 추가되면 반영될 것 같아 PR 우선 올리겠습니다.

## 🚨 관련 이슈 번호

- #55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 최근 스토리를 동적으로 불러와 보여주는 캐러셀 기능이 추가되었습니다.
  - 좋아요 기능 실패 시 로그인 필요, 중복 좋아요, 기타 오류에 대한 안내 모달이 추가되었습니다.

- **Style**
  - "많은 응원을 받은 이야기" 제목의 상단 여백이 늘어났습니다.
  - 스토리 캐러셀 카드의 좋아요 버튼 모서리가 더 둥글게 변경되고, 제목 글꼴이 더 두꺼워졌으며 줄바꿈 스타일이 개선되었습니다.

- **Refactor**
  - 스토리 캐러셀이 정적 목록에서 API를 통한 동적 데이터 렌더링 방식으로 변경되었습니다.
  - 카테고리 캐러셀이 페이지에서 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->